### PR TITLE
[OPS-1192] Fix escaping issues for secret files

### DIFF
--- a/scripts/write_secrets.py
+++ b/scripts/write_secrets.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+# Helper script for writing secrets fetched from vault to the file system.
+# Usage: write_secrets.py [--base64] <secret-directory>
+
+import base64
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+
+# with `--base64` flag, values are expected to be in base64
+secretsAreBase64 = False
+if len(args) >= 1 and args[0] == "--base64":
+  secretsAreBase64 = True
+  args = args[1:]
+
+# directory to write secrets to
+secretsPath = args[0]
+
+# get vault response from stdin
+response = json.load(sys.stdin)
+
+# write each secret to a file
+data = response['data']['data']
+if data != None:
+  for name, value in data.items():
+    secret_path = pathlib.Path(secretsPath, name)
+    print(f'Writing to {secret_path}', file=sys.stderr)
+    if secretsAreBase64:
+      decoded_value = base64.b64decode(value)
+      secret_path.write_bytes(decoded_value)
+    else:
+      secret_path.write_text(value)

--- a/tests/modules/vault-secrets.nix
+++ b/tests/modules/vault-secrets.nix
@@ -29,6 +29,7 @@
           script = ''
             ls '${config.vault-secrets.secrets.test}'
             cat '${config.vault-secrets.secrets.test}/test_file' | grep 'Test file contents!'
+            cat '${config.vault-secrets.secrets.test}/check_escaping' | grep "\"'\`"
             env
             echo $HELLO | grep 'Hello, World'
           '';
@@ -91,7 +92,9 @@
 
         # Put secrets for the test unit into Vault
         vault kv put kv/test/environment HELLO='Hello, World'
-        vault kv put kv/test/secrets test_file='Test file contents!'
+        vault kv put kv/test/secrets \
+          test_file='Test file contents!' \
+          check_escaping="\"'\`"
 
         # Set up SSH hostkey to connect to the client
         cat ${ssh-keys.snakeOilPrivateKey} > privkey.snakeoil


### PR DESCRIPTION
Vault-secrets module writes secret values to files by generating a bash
command and calling `eval` on it, which can cause subtle issues when
a secret contains something that looks like an actual bash command. We
would want to make sure that secret values parsed from json are properly
escaped, which is practically impossible in bash, but trivial in any
other language. So I've made a small python script which parses json
response from vault and writes corresponding secrets to the file system,
and handles base64 decoding as well.

I also added a primitive test case for this issue.

For `environment` secrets we still have this issue, but it's much harder
to fix because systemd environment files have some custom format, so
we have to be carefull with what values we use for environment
variables.