### PR TITLE
Make scripts proper derivations with type = derivation

### DIFF
--- a/scripts/vault-push-approle-envs.nix
+++ b/scripts/vault-push-approle-envs.nix
@@ -16,6 +16,8 @@
         "${config.networking.hostName}.${config.networking.domain}");
   };
 
+  type = "derivation";
+
   __toString = self:
     let
 

--- a/scripts/vault-push-approles.nix
+++ b/scripts/vault-push-approles.nix
@@ -16,6 +16,8 @@
   */
   # pkgs.vault-push-approles { } { extraApproles = [ { ... } ] }
 
+  type = "derivation";
+
   # `final` contains fixed-point functions after applying user-supplied overrides
   overrideable = final: {
 


### PR DESCRIPTION
In NixOS/nixpkgs?rev=93681a52a5bff48ecf434d3225588c1c99c1e853
a check for the derivationness of all elements of `buildInputs` and
`nativeBuildInputs` got introduced. This used to work because the script coerce
implicitly into strings due to `__toString`, but in fact they weren't proper
derivations, probably still aren't but it works.

Signed-off-by: Magic_RB <magic_rb@redalder.org>