### PR TITLE
Generate proper 'PartOf' for secret service

### DIFF
--- a/modules/vault-secrets.nix
+++ b/modules/vault-secrets.nix
@@ -15,7 +15,7 @@ in
       name: scfg: nameValuePair "${name}-secrets" {
         path = with pkgs; [ getent jq vault-bin python3 ];
 
-        partOf = map (n: "${name}.service") scfg.services;
+        partOf = map (n: "${n}.service") scfg.services;
         wantedBy = optional (scfg.services == []) "multi-user.target" ;
 
         # network is needed to access the vault server


### PR DESCRIPTION
Problem: Currently 'PartOf' list can only consist of '${name}.service' strings. As a result, 'services' option doesn't work as expected.

Solution: Use actual names of services from 'services' option list.