### PR TITLE
Add vault login retries

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,7 +3,7 @@ on: push
 
 jobs:
   check:
-    runs-on: self-hosted
+    runs-on: [nix, self-hosted]
     steps:
       - uses: actions/checkout@v3
 

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -134,6 +134,17 @@ let
           '';
         };
 
+        loginRetries = mkOption {
+          type = with types; int;
+          default = 5;
+          description = ''
+            Number of attempts script will try to login into Vault.
+            This may be useful in case secrets service is restarted when internet
+            connection is not yet available. Sadly After=network-online.target
+            doesn't always guarantee that.
+          '';
+        };
+
         __toString = mkOption {
           default = _: "${cfg.outPrefix}/${name}";
           readOnly = true;


### PR DESCRIPTION
Problem: During massive updates secrets services are restarted when 'After=network-online.target' is satisfied but still there is no internet connection. As a result login to vault fails and deployment is considered as failed due to service failure.

Solution: Add option that will configure the amount of vault login retries and actually perform retry in script when login fails.

Sadly, it's not viable to do this retry via systemd, even though 'Restart=on-failure' is available for oneshot service, due to the fact that service will fail and cause the NixOS activation to stop and rollback despite the fact that this service will attempt to restart afterwards.