### PR TITLE
[Chore] Fix snippet in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,22 +26,22 @@ in {
     vaultPrefix = "kv/servers/${config.networking.hostName}";
     vaultAddress = "https://vault.example.com:8200";
 
-    # Define a secret called `something`, with default options.
-    secrets.example = {};
+    # Define a secret called `mysecret`, with default options.
+    secrets.mysecret = {};
   };
 
-  services.example = {
+  services.myservice = {
     enable = true;
-    environmentFile = "${vs.something}/environment";
+    environmentFile = "${vs.mysecret}/environment";
   };
 }
 ```
 
-In this example, we define a secret `example` for a service also called
-`example`. The AppRole used to log in will be `example` as well. In order to
+In this example, we define a secret `mysecret` for a service called
+`myservice`. The AppRole used to log in will be `myservice`. In order to
 log in using such an AppRole, it first needs to be created in Vault, and
 credentials for it need to be generated, and placed in
-`/etc/vault-secrets.env.d/example`. This file should be formatted according to
+`/etc/vault-secrets.env.d/myservice`. This file should be formatted according to
 systemd `EnvironmentFile`, and contain the variables `VAULT_ROLE_ID` and
 `VAULT_SECRET_ID`, both of which are UUID provided by Vault. Using the
 script generators documented below significantly simplifies the process.
@@ -49,9 +49,9 @@ script generators documented below significantly simplifies the process.
 The secrets themselves will be fetched from Vault from two specific paths under
 `vaultPrefix`. In this example, it will query `kv/servers/hostname/environment`
 and `kv/servers/hostname/secrets`. Any keys defined in `environment` will be
-dumped into `/run/secrets/example/environment` in a format suitable for usage
+dumped into `/run/secrets/mysecret/environment` in a format suitable for usage
 with systemd `EnvironmentFile`. Any keys defined in `secrets` will be dumped
-into individual files under `/run/secrets/example`, named after the keys, and
+into individual files under `/run/secrets/mysecret`, named after the keys, and
 containing the corresponding value. The values of `secrets` may optionally be
 flagged as `base64` encoded, which is recommended if you need to store binary
 data or multiline text, as Vault has a bad habit of mangling these.


### PR DESCRIPTION
Problem: the README snippet was invalid. There was a secret called example which was later referred as something, but still referred in the documentation as example.

Solution: fix this confusing example by naming things consistently and uniquely. Having different names for different concepts makes easier for everyone to understand the description following the snippet