### PR TITLE
Fix hostNameOverrides typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,6 @@ want to override some hostnames, use `hostnameOverrides` like this:
 
 ```nix
 vault-push-approle-envs self {
-  hostnameOverrides."<attribute name in nixosConfigurations>" = "new.host.name";
+  hostNameOverrides."<attribute name in nixosConfigurations>" = "new.host.name";
 }
 ```


### PR DESCRIPTION
This was a typo as [/scripts/vault-push-approle-envs.nix](https://github.com/serokell/vault-secrets/blob/0fbb2cada27ee335997799d340092d171ab296a3/scripts/vault-push-approle-envs.nix#L12) uses a different capitalization.