### PR TITLE
[Chore] Add systemd unit restart policy

### DIFF
--- a/modules/vault-secrets.nix
+++ b/modules/vault-secrets.nix
@@ -1,11 +1,11 @@
-# SPDX-FileCopyrightText: 2020 Serokell <https://serokell.io/>
+# SPDX-FileCopyrightText: 2020-2023 Serokell <https://serokell.io/>
 #
 # SPDX-License-Identifier: MPL-2.0
 
 { config, lib, pkgs, ... }:
 let
   cfg = config.vault-secrets;
-  inherit (lib) mkMerge flip mapAttrs' nameValuePair optional;
+  inherit (lib) mkMerge mkDefault flip mapAttrs' nameValuePair optional;
 in
 {
   options = import ./options.nix { inherit lib cfg pkgs; };
@@ -26,11 +26,16 @@ in
 
         script = import ./script.nix { inherit cfg scfg lib name; };
 
+        startLimitBurst = mkDefault 5;
+        startLimitIntervalSec = mkDefault 300;
+
         serviceConfig = {
           EnvironmentFile = scfg.environmentFile;
           RemainAfterExit = true;
           Type = "oneshot";
           UMask = "0077";
+          Restart = mkDefault "on-failure";
+          RestartSec = mkDefault 10;
         };
       }
     ))] ++ (flip lib.mapAttrsToList cfg.secrets (


### PR DESCRIPTION
Problem: By default, systemd services generated from the NixOS system configuration don't attempt to restart on failure since Restart=no. However, in some cases, running processes can fail for unclear reasons, and the simplest way to bring the failed service back to life is to restart it. Instead, currently, the service will fail and trigger an alert without attempting to restart.

Solution: Add default values for startLimitBurst, startLimitIntervalSec, Restart, and RestartSec.