### PR TITLE
Allow overriding ssh options per configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,24 @@ of the script generator).
 
 This script fetches approle credentials from Vault and then pushes those
 credentials to the servers, so that the module can authenticate to Vault.
-It guesses server hostnames from their `networking` config option. If you
-want to override some hostnames, use `hostnameOverrides` like this:
+By default, the ssh hostnames and options are guessed from their `networking`
+config option. If you want to override the options for some hostnames, use
+`getConfigurationOverrides` like this:
+
+```nix
+vault-push-approle-envs self {
+  getConfigurationOverrides = { attrName, ... }: {
+    "<attribute name in nixosConfigurations>" = {
+      # all of these are optional. override just what you need.
+      hostname = "new.host.name";
+      sshUser = "remote_ssh_user";
+      sshOpts = [ "-i" "ssh_host/key" ];
+    };
+  }.${attrName};
+}
+```
+
+Another option is the older `hostNameOverrides` for simpler, hostname-only overrides:
 
 ```nix
 vault-push-approle-envs self {


### PR DESCRIPTION
Problem: Currently, there is no way to override the ssh options of `vault-push-approle-envs` in nix at all. One can set the `SSH_OPTS` env variable, but that sets the options for all configurations, which might not be desirable if you want to use host-specific options like the key file location.

Solution: Extend the existing override system to allow overriding not only the hostname but also the SSH options. As an added treat because it was easy to do, I've also added an option for overriding the remote ssh user.

Note: The current methods of overriding the hostname should still work correctly and there shouldn't be any backwards incompatibility.