### PR TITLE
flake: Remove flake-utils input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,41 +118,7 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nix": "nix",
-        "nixpkgs": "nixpkgs_2",
-        "utils": "utils"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
+        "nixpkgs": "nixpkgs_2"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
     };
   };
 
-  outputs = { self, nixpkgs, nix, flake-utils, ... }@inputs:
+  outputs = { self, nixpkgs, nix, ... }@inputs:
     let
       forSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" ];
     in
@@ -22,6 +22,7 @@
       };
 
       nixosModules.vault-secrets = import ./modules/vault-secrets.nix;
+      darwinModules.vault-secrets = import ./modules/vault-secrets-darwin.nix;
 
       checks = forSystems (system:
         let

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,6 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    utils.url = "github:numtide/flake-utils";
     flake-compat = {
       url = "github:edolstra/flake-compat";
       flake = false;
@@ -11,32 +10,32 @@
   };
 
   outputs = { self, nixpkgs, nix, flake-utils, ... }@inputs:
+    let
+      forSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" ];
+    in
     {
+      overlays.default = final: prev: {
+        vault-push-approles =
+          final.callPackage ./scripts/vault-push-approles.nix { };
+        vault-push-approle-envs =
+          final.callPackage ./scripts/vault-push-approle-envs.nix { };
+      };
 
-    overlay = final: prev: {
-      vault-push-approles =
-        final.callPackage ./scripts/vault-push-approles.nix { };
-      vault-push-approle-envs =
-        final.callPackage ./scripts/vault-push-approle-envs.nix { };
-    };
+      nixosModules.vault-secrets = import ./modules/vault-secrets.nix;
 
-    nixosModules.vault-secrets = import ./modules/vault-secrets.nix;
-    darwinModules.vault-secrets = import ./modules/vault-secrets-darwin.nix;
-
-    } // (flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-        inherit (pkgs) lib;
-        inherit (lib) mapAttrs;
-      in {
-        checks = let
+      checks = forSystems (system:
+        let
           tests = import ./tests/modules/all-tests.nix {
-            inherit pkgs system self;
+            pkgs = nixpkgs.legacyPackages.${system};
+            inherit system self;
             callTest = t: t.test;
             nixosPath = "${nixpkgs}/nixos";
           };
-        in { inherit (tests) vault-secrets; };
+        in
+        { inherit (tests) vault-secrets; });
 
-        legacyPackages = nixpkgs.legacyPackages.${system}.extend self.overlay;
-      }));
+      legacyPackages = forSystems (system:
+        nixpkgs.legacyPackages.${system}.extend
+          self.overlays.default);
+    };
 }

--- a/tests/modules/vault-secrets.nix
+++ b/tests/modules/vault-secrets.nix
@@ -42,7 +42,7 @@
 
         services.openssh = {
           enable = true;
-          permitRootLogin = "yes";
+          settings.PermitRootLogin = "yes";
         };
 
         users.users.root = {


### PR DESCRIPTION
Removes the dependency on flake utils. Also fixes a test warning about the renamed `permitRootLogin` option for openssh.

Fixes #36